### PR TITLE
fix: remove arlac77/npm-template-sync-github-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "template": {
     "usedBy": [
       "arlac77/npm-dep-graph",
-      "arlac77/npm-template-sync-github-hook",
       "arlac77/template-kronos-app",
       "arlac77/template-web-app",
       "k0nsti/konsum"


### PR DESCRIPTION
fix: remove arlac77/npm-template-sync-github-hook